### PR TITLE
Add email forwarding functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !app.json
 
 .DS_STORE
+**/.mockup.pdf.icloud

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,6 +42,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+            <version>2.3.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>5.2.8.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/net/finman/controller/EmailController.java
+++ b/backend/src/main/java/net/finman/controller/EmailController.java
@@ -1,13 +1,5 @@
 package net.finman.controller;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-
-import javax.mail.MessagingException;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,11 +22,12 @@ public class EmailController {
     private EmailService emailService;
 
     private static final String EMAIL_SUBJECT = "Invoice from A.Finman";
-    private static final String EMAIL_BODY = "Hello here is your invoice pls pay q:^)"; 
+    private static final String EMAIL_BODY = "Hello here is your invoice pls pay q:^)";
 
     @PostMapping("/send-invoice")
-	public ResponseEntity<?> sendInvoice(@RequestParam("file") MultipartFile file, @RequestParam("to") String to) throws EmailNotSentException {
+    public ResponseEntity<?> sendInvoice(@RequestParam("file") MultipartFile file, @RequestParam("to") String to)
+            throws EmailNotSentException {
         emailService.sendEmailWithAttachment(to, EMAIL_SUBJECT, EMAIL_BODY, file);
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/net/finman/controller/EmailController.java
+++ b/backend/src/main/java/net/finman/controller/EmailController.java
@@ -1,0 +1,58 @@
+package net.finman.controller;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.mail.MessagingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.finman.service.EmailService;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api")
+public class EmailController {
+
+    @Autowired
+    private EmailService emailService;
+    
+    @PostMapping("/send-invoice")
+	public ResponseEntity<?> sendInvoice(@RequestParam("file") MultipartFile file) {
+
+        File attachment = convertToFile(file);
+
+        try {
+            System.out.println("!!");
+            emailService.sendEmailWithAttachment("yenanw@mail.com", "Invoice from A.Finman", "Hello here is your invoice pls pay q:^)", attachment);
+        } catch (MessagingException e) {
+            e.printStackTrace();
+            return ResponseEntity.notFound().build();
+        }
+        
+		return ResponseEntity.ok().build();
+	}
+
+
+    private File convertToFile(MultipartFile mulFile) {
+        File file = new File("src/main/resources/invoice.pdf");
+        System.out.println("!!!");
+        try {
+            mulFile.transferTo(file);
+        } catch (IllegalStateException | IOException e) {
+            e.printStackTrace();
+        }
+
+        return file;
+    }
+}

--- a/backend/src/main/java/net/finman/controller/EmailController.java
+++ b/backend/src/main/java/net/finman/controller/EmailController.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import javax.mail.MessagingException;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import net.finman.exception.EmailNotSentException;
 import net.finman.service.EmailService;
 
 @CrossOrigin(origins = "*")
@@ -26,33 +28,13 @@ public class EmailController {
 
     @Autowired
     private EmailService emailService;
-    
+
+    private static final String EMAIL_SUBJECT = "Invoice from A.Finman";
+    private static final String EMAIL_BODY = "Hello here is your invoice pls pay q:^)"; 
+
     @PostMapping("/send-invoice")
-	public ResponseEntity<?> sendInvoice(@RequestParam("file") MultipartFile file) {
-
-        File attachment = convertToFile(file);
-
-        try {
-            System.out.println("!!");
-            emailService.sendEmailWithAttachment("yenanw@mail.com", "Invoice from A.Finman", "Hello here is your invoice pls pay q:^)", attachment);
-        } catch (MessagingException e) {
-            e.printStackTrace();
-            return ResponseEntity.notFound().build();
-        }
-        
-		return ResponseEntity.ok().build();
+	public ResponseEntity<?> sendInvoice(@RequestParam("file") MultipartFile file, @RequestParam("to") String to) throws EmailNotSentException {
+        emailService.sendEmailWithAttachment(to, EMAIL_SUBJECT, EMAIL_BODY, file);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
-
-
-    private File convertToFile(MultipartFile mulFile) {
-        File file = new File("src/main/resources/invoice.pdf");
-        System.out.println("!!!");
-        try {
-            mulFile.transferTo(file);
-        } catch (IllegalStateException | IOException e) {
-            e.printStackTrace();
-        }
-
-        return file;
-    }
 }

--- a/backend/src/main/java/net/finman/exception/EmailNotSentException.java
+++ b/backend/src/main/java/net/finman/exception/EmailNotSentException.java
@@ -1,0 +1,14 @@
+package net.finman.exception;
+
+public class EmailNotSentException extends Exception {
+    private String details;
+
+    public EmailNotSentException(String message, String details) {
+        super(message);
+        this.details = details;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+}

--- a/backend/src/main/java/net/finman/exception/ErrorHandler.java
+++ b/backend/src/main/java/net/finman/exception/ErrorHandler.java
@@ -12,7 +12,8 @@ public class ErrorHandler {
 
     @ExceptionHandler(ResourceNotCreatedException.class)
     public ResponseEntity<?> resourceNotCreatedException(ResourceNotCreatedException e) {
-        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()),
+                HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
@@ -22,15 +23,19 @@ public class ErrorHandler {
 
     @ExceptionHandler(ResourceNotDeletedException.class)
     public ResponseEntity<?> resourceNotDeletedException(ResourceNotDeletedException e) {
-        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()),
+                HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ResourceNotUpdatedException.class)
     public ResponseEntity<?> resourceNotUpdatedException(ResourceNotUpdatedException e) {
-        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()),
+                HttpStatus.BAD_REQUEST);
     }
+
     @ExceptionHandler(EmailNotSentException.class)
     public ResponseEntity<?> emailNotSendException(EmailNotSentException e) {
-        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()),
+                HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/net/finman/exception/ErrorHandler.java
+++ b/backend/src/main/java/net/finman/exception/ErrorHandler.java
@@ -29,4 +29,8 @@ public class ErrorHandler {
     public ResponseEntity<?> resourceNotUpdatedException(ResourceNotUpdatedException e) {
         return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
     }
+    @ExceptionHandler(EmailNotSentException.class)
+    public ResponseEntity<?> emailNotSendException(EmailNotSentException e) {
+        return new ResponseEntity<>(new ErrorDetails(new Date(), e.getMessage(), e.getDetails()), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/backend/src/main/java/net/finman/service/EmailService.java
+++ b/backend/src/main/java/net/finman/service/EmailService.java
@@ -1,9 +1,22 @@
 package net.finman.service;
 
-import java.io.File;
-
 import javax.mail.MessagingException;
 
+import org.springframework.core.io.InputStreamSource;
+
+import net.finman.exception.EmailNotSentException;
+
 public interface EmailService {
-    void sendEmailWithAttachment(String to, String subject, String text, File attachment) throws MessagingException;
+    
+    /**
+     * Sends an email with an attachment to the given mail adress
+     * 
+     * @param to The person to recieve the mail
+     * @param subject Subject of mail
+     * @param text Body of mail
+     * @param attachment The attached file to the mail, should be invoice pdf
+     * @throws EmailNotSentException
+     * @throws MessagingException When the email failed to send
+     */
+    void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment) throws EmailNotSentException;
 }

--- a/backend/src/main/java/net/finman/service/EmailService.java
+++ b/backend/src/main/java/net/finman/service/EmailService.java
@@ -7,16 +7,17 @@ import org.springframework.core.io.InputStreamSource;
 import net.finman.exception.EmailNotSentException;
 
 public interface EmailService {
-    
+
     /**
      * Sends an email with an attachment to the given mail adress
      * 
-     * @param to The person to recieve the mail
-     * @param subject Subject of mail
-     * @param text Body of mail
+     * @param to         The person to recieve the mail
+     * @param subject    Subject of mail
+     * @param text       Body of mail
      * @param attachment The attached file to the mail, should be invoice pdf
      * @throws EmailNotSentException
-     * @throws MessagingException When the email failed to send
+     * @throws MessagingException    When the email failed to send
      */
-    void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment) throws EmailNotSentException;
+    void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment)
+            throws EmailNotSentException;
 }

--- a/backend/src/main/java/net/finman/service/EmailService.java
+++ b/backend/src/main/java/net/finman/service/EmailService.java
@@ -1,0 +1,9 @@
+package net.finman.service;
+
+import java.io.File;
+
+import javax.mail.MessagingException;
+
+public interface EmailService {
+    void sendEmailWithAttachment(String to, String subject, String text, File attachment) throws MessagingException;
+}

--- a/backend/src/main/java/net/finman/service/EmailServiceImpl.java
+++ b/backend/src/main/java/net/finman/service/EmailServiceImpl.java
@@ -1,0 +1,35 @@
+package net.finman.service;
+
+import java.io.File;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    @Autowired
+    private JavaMailSender emailSender;
+
+    @Override
+    public void sendEmailWithAttachment(String to, String subject, String text, File attachment) throws MessagingException {
+
+        MimeMessage message = emailSender.createMimeMessage();
+
+        MimeMessageHelper helper = new MimeMessageHelper(message, true);
+        
+        helper.setFrom("alexIsNoob@noobmail.com");
+        helper.setTo(to);
+        helper.setSubject(subject);
+        helper.setText(text);
+        helper.addAttachment("invoice.pdf", attachment);
+
+        emailSender.send(message);
+    }
+    
+}

--- a/backend/src/main/java/net/finman/service/EmailServiceImpl.java
+++ b/backend/src/main/java/net/finman/service/EmailServiceImpl.java
@@ -1,14 +1,15 @@
 package net.finman.service;
 
-import java.io.File;
-
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamSource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+
+import net.finman.exception.EmailNotSentException;
 
 @Service
 public class EmailServiceImpl implements EmailService {
@@ -17,19 +18,21 @@ public class EmailServiceImpl implements EmailService {
     private JavaMailSender emailSender;
 
     @Override
-    public void sendEmailWithAttachment(String to, String subject, String text, File attachment) throws MessagingException {
+    public void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment) throws EmailNotSentException{
+        try {
+            MimeMessage message = emailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
-        MimeMessage message = emailSender.createMimeMessage();
+            helper.setFrom("alexIsNoob@noobmail.com");
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(text);
+            helper.addAttachment("invoice.pdf", attachment);
 
-        MimeMessageHelper helper = new MimeMessageHelper(message, true);
-        
-        helper.setFrom("alexIsNoob@noobmail.com");
-        helper.setTo(to);
-        helper.setSubject(subject);
-        helper.setText(text);
-        helper.addAttachment("invoice.pdf", attachment);
-
-        emailSender.send(message);
+            emailSender.send(message);
+        } catch (MessagingException e) {
+            throw new EmailNotSentException("The email was not sent!", e.getMessage());
+        }
     }
     
 }

--- a/backend/src/main/java/net/finman/service/EmailServiceImpl.java
+++ b/backend/src/main/java/net/finman/service/EmailServiceImpl.java
@@ -18,7 +18,8 @@ public class EmailServiceImpl implements EmailService {
     private JavaMailSender emailSender;
 
     @Override
-    public void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment) throws EmailNotSentException{
+    public void sendEmailWithAttachment(String to, String subject, String text, InputStreamSource attachment)
+            throws EmailNotSentException {
         try {
             MimeMessage message = emailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
@@ -34,5 +35,5 @@ public class EmailServiceImpl implements EmailService {
             throw new EmailNotSentException("The email was not sent!", e.getMessage());
         }
     }
-    
+
 }

--- a/backend/src/main/java/net/finman/service/EmailServiceImpl.java
+++ b/backend/src/main/java/net/finman/service/EmailServiceImpl.java
@@ -24,7 +24,6 @@ public class EmailServiceImpl implements EmailService {
             MimeMessage message = emailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
-            helper.setFrom("alexIsNoob@noobmail.com");
             helper.setTo(to);
             helper.setSubject(subject);
             helper.setText(text);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,9 +7,12 @@ spring.datasource.schema=classpath:/schema.sql
 spring.datasource.continue-on-error=true
 
 # email stuff
-spring.mail.host=smtp.mailtrap.io
+#spring.mail.host=smtp.mailtrap.io
+spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=b1de5fb9d1c2ea
-spring.mail.password=c79811872bf652
+spring.mail.username=sonywalkmanwmfx199@gmail.com
+spring.mail.password=wmhiepckvrnrkvjp
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+spring.http.multipart.max-file-size = 100MB
+spring.http.multipart.max-request-size = 100MB

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,15 @@
+# database stuff
 spring.datasource.url=jdbc:postgresql://ec2-54-74-156-137.eu-west-1.compute.amazonaws.com:5432/dsjq7j82jtrnh
 spring.datasource.username=yggqvltjeyngur
 spring.datasource.password=bf6b3cc736071e5b87355aa546a2b9d7dfde08a783e75c86ef9c816ed9219052
 spring.datasource.initialization-mode=always
 spring.datasource.schema=classpath:/schema.sql
 spring.datasource.continue-on-error=true
+
+# email stuff
+spring.mail.host=smtp.mailtrap.io
+spring.mail.port=587
+spring.mail.username=b1de5fb9d1c2ea
+spring.mail.password=c79811872bf652
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,18 +1,17 @@
 # database stuff
-spring.datasource.url=jdbc:postgresql://ec2-54-74-156-137.eu-west-1.compute.amazonaws.com:5432/dsjq7j82jtrnh
-spring.datasource.username=yggqvltjeyngur
-spring.datasource.password=bf6b3cc736071e5b87355aa546a2b9d7dfde08a783e75c86ef9c816ed9219052
+spring.datasource.url=jdbc:postgresql://ec2-54-155-92-75.eu-west-1.compute.amazonaws.com:5432/deq4n9gdg6f5u7
+spring.datasource.username=fkovvrxzkexhkb
+spring.datasource.password=d55eb9e46f680f754e9701b0bd01e070151601d7edce1d6e7cfd4e4769857156
 spring.datasource.initialization-mode=always
 spring.datasource.schema=classpath:/schema.sql
 spring.datasource.continue-on-error=true
 
 # email stuff
-#spring.mail.host=smtp.mailtrap.io
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=sonywalkmanwmfx199@gmail.com
 spring.mail.password=wmhiepckvrnrkvjp
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
-spring.http.multipart.max-file-size = 100MB
-spring.http.multipart.max-request-size = 100MB
+spring.http.multipart.max-file-size = 8MB
+spring.http.multipart.max-request-size = 8MB


### PR DESCRIPTION
Added a function to send an email with an attachment called `invoice.pdf`.

- The email is currently sent from `sonywalkmanwmfx199@gmail.com`.
- The API controller assumes a request body of `form-data` type containing two key-value pairs.
   - "file": The PDF-file of the invoice
   - "to": The mail address to forward the email to

_<sub>This may or may not work on other devices</sub>_